### PR TITLE
Fix pagination

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -45,6 +45,18 @@ module.exports = function (config) {
     return articles.user.publication.posts;
   });
 
+  config.addFilter("nextArticle", (articlez, page, modifier = 1) => {
+    const parts = page.outputPath.split("/");
+    parts.pop(); // get rid of `index.html`
+    const slug = parts.pop();
+    for (const [index, article] of articlez.entries()) {
+      const target = index + modifier;
+      if (article.slug === slug && target >= 0 && target < articlez.length) {
+        return articlez[target];
+      }
+    }
+  });
+
   // config.addPassthroughCopy("src/assets/css/**/*");
   config.addPassthroughCopy("src/assets/css/index.css");
 

--- a/src/_includes/partials/_paginate.njk
+++ b/src/_includes/partials/_paginate.njk
@@ -1,11 +1,9 @@
-{% set previousPost = collections.articlez | getPreviousCollectionItem(page) %}
-{% set nextPost = collections.articlez | getNextCollectionItem(page) %}
+{% set previousPost = collections.articlez | nextArticle(page) %}
+{% set nextPost = collections.articlez | nextArticle(page, -1) %}
 
+<pre style="white-space: pre-wrap;">{{ previousPost | dump }}</pre>
+<pre style="white-space: pre-wrap;">{{ nextPost | dump }}</pre>
     
-    <pre>{{page | dump}}</pre>
-    <pre>{{previousPost | dump}}</pre>
-    <pre>{{nextPost | dump}}</pre>
-
 <div class="flex justify-around bg-gray-900 text-gray-100">
     <p>{% if previousPost %}Previous Blog Post: <a href="{{ previousPost.url }}">{{ previousPost.data.title }}</a>{% endif %}</p>
     <p>{% if nextPost %}Next Blog Post: <a href="{{ nextPost.url }}">{{ nextPost.data.title }}</a>{% endif %}</p>


### PR DESCRIPTION
Adds a `nextArticle` filter based on the data. You’ll need to rebuild the links themselves using the information you have—it’s `dump`ed on the page for you to see.